### PR TITLE
Better input maps

### DIFF
--- a/addons/gevp/scripts/vehicle.gd
+++ b/addons/gevp/scripts/vehicle.gd
@@ -648,11 +648,11 @@ func _physics_process(delta : float) -> void:
 			automatic_transmission = not automatic_transmission
 	
 	if string_shift_up != "":
-		if Input.is_action_just_pressed("Shift Up"):
+		if Input.is_action_just_pressed(string_shift_up):
 			manual_shift(1)
 	
 	if string_shift_down != "":
-		if Input.is_action_just_pressed("Shift Down"):
+		if Input.is_action_just_pressed(string_shift_down):
 			manual_shift(-1)
 	
 	# Reverse gear logic

--- a/addons/gevp/scripts/vehicle.gd
+++ b/addons/gevp/scripts/vehicle.gd
@@ -4,56 +4,6 @@
 class_name Vehicle
 extends RigidBody3D
 
-@export_group("Input Maps", "string_")
-## The name of the input map used for this vehicle's brakes input.
-##
-## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
-## [br]Leave blank to disable.
-@export var string_brake_input: String = "Brakes"
-## The name of the input map used for steering this vehicle left.
-##
-## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
-## [br]Leave blank to disable.
-@export var string_steer_left: String = "Steer Left"
-## The name of the input map used for steering this vehicle right.
-##
-## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
-## [br]Leave blank to disable.
-@export var string_steer_right: String = "Steer Right"
-## The name of the input map used for this vehicle's throttle input.
-##
-## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
-## [br]Leave blank to disable.
-@export var string_throttle_input: String = "Throttle"
-## The name of the input map used for this vehicle's handbrake input.
-##
-## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
-## [br]Leave blank to disable.
-@export var string_handbrake_input: String = "Handbrake"
-## The name of the input map used for this vehicle's clutch input.
-##
-## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
-## [br]Leave blank to disable.
-@export var string_clutch_input: String = "Clutch"
-## The name of the input map used for enabling or disabling
-##
-## the transmission of this vehicle.
-## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
-## [br]Leave blank to disable.
-@export var string_toggle_transmission: String = "Toggle Transmission"
-## The name of the input map used for shifting up a gear when
-##
-## manual transmission is enabled.
-## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
-## [br]Leave blank to disable.
-@export var string_shift_up: String = "Shift Up"
-## The name of the input map used for shiftinf down a gear when
-##
-## manual transmission is enabled.
-## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
-## [br]Leave blank to disable.
-@export var string_shift_down: String = "Shift Down"
-
 @export_group("Wheel Nodes")
 ## Assign this to the Wheel [RayCast3D] that is this vehicle's front left wheel.
 @export var front_left_wheel : Wheel
@@ -655,41 +605,6 @@ func initialize():
 func _physics_process(delta : float) -> void:
 	if not is_ready:
 		return
-	
-	# Vehicle controller logic ported and modified from vehicle_controllergd.gd
-
-	if string_brake_input != "":
-		brake_input = Input.get_action_strength(string_brake_input)
-
-	if string_steer_left != "" and string_steer_right != "":
-		steering_input = Input.get_action_strength(string_steer_left) - Input.get_action_strength(string_steer_right)
-
-	if string_throttle_input != "":
-		throttle_input = pow(Input.get_action_strength(string_throttle_input), 2.0)
-
-	if string_handbrake_input != "":
-		handbrake_input = Input.get_action_strength(string_handbrake_input)
-	
-	if string_clutch_input != "":
-		clutch_input = clampf(Input.get_action_strength(string_clutch_input) + Input.get_action_strength(string_handbrake_input), 0.0, 1.0)
-	
-	if string_toggle_transmission != "":
-		if Input.is_action_just_pressed(string_toggle_transmission):
-			automatic_transmission = not automatic_transmission
-	
-	if string_shift_up != "":
-		if Input.is_action_just_pressed(string_shift_up):
-			manual_shift(1)
-	
-	if string_shift_down != "":
-		if Input.is_action_just_pressed(string_shift_down):
-			manual_shift(-1)
-	
-	# Reverse gear logic
-
-	if current_gear == -1:
-		brake_input = Input.get_action_strength(string_throttle_input)
-		throttle_input = Input.get_action_strength(string_brake_input)
 	
 	## For stability calculations, we need the vehicle body inertia which isn't
 	## available immediately

--- a/addons/gevp/scripts/vehicle_controllergd.gd
+++ b/addons/gevp/scripts/vehicle_controllergd.gd
@@ -1,23 +1,4 @@
 extends Node3D
 
-@export var vehicle_node : Vehicle
-
-func _physics_process(delta):
-	vehicle_node.brake_input = Input.get_action_strength("Brakes")
-	vehicle_node.steering_input = Input.get_action_strength("Steer Left") - Input.get_action_strength("Steer Right")
-	vehicle_node.throttle_input = pow(Input.get_action_strength("Throttle"), 2.0)
-	vehicle_node.handbrake_input = Input.get_action_strength("Handbrake")
-	vehicle_node.clutch_input = clampf(Input.get_action_strength("Clutch") + Input.get_action_strength("Handbrake"), 0.0, 1.0)
-	
-	if Input.is_action_just_pressed("Toggle Transmission"):
-		vehicle_node.automatic_transmission = !vehicle_node.automatic_transmission
-	
-	if Input.is_action_just_pressed("Shift Up"):
-		vehicle_node.manual_shift(1)
-	
-	if Input.is_action_just_pressed("Shift Down"):
-		vehicle_node.manual_shift(-1)
-	
-	if vehicle_node.current_gear == -1:
-		vehicle_node.brake_input = Input.get_action_strength("Throttle")
-		vehicle_node.throttle_input = Input.get_action_strength("Brakes")
+func _physics_process(_delta):
+	pass # Handled by vehicle.gd

--- a/addons/gevp/scripts/vehicle_controllergd.gd
+++ b/addons/gevp/scripts/vehicle_controllergd.gd
@@ -1,4 +1,81 @@
 extends Node3D
 
+## The Vehicle that this vehicle controller will send
+## input values to. Required for the vehicle controller to work properly.
+@export var vehicle_node : Vehicle
+
+@export_group("Input Maps", "string_")
+## The name of the input map used for this vehicle's brakes input.
+## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
+## [br]Leave blank to disable.
+@export var string_brake_input: String = "Brakes"
+## The name of the input map used for steering this vehicle left.
+## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
+## [br]Leave blank to disable.
+@export var string_steer_left: String = "Steer Left"
+## The name of the input map used for steering this vehicle right.
+## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
+## [br]Leave blank to disable.
+@export var string_steer_right: String = "Steer Right"
+## The name of the input map used for this vehicle's throttle input.
+## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
+## [br]Leave blank to disable.
+@export var string_throttle_input: String = "Throttle"
+## The name of the input map used for this vehicle's handbrake input.
+## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
+## [br]Leave blank to disable.
+@export var string_handbrake_input: String = "Handbrake"
+## The name of the input map used for this vehicle's clutch input.
+## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
+## [br]Leave blank to disable.
+@export var string_clutch_input: String = "Clutch"
+## The name of the input map used for enabling or disabling
+## the transmission of this vehicle.
+## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
+## [br]Leave blank to disable.
+@export var string_toggle_transmission: String = "Toggle Transmission"
+## The name of the input map used for shifting up a gear when
+## manual transmission is enabled.
+## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
+## [br]Leave blank to disable.
+@export var string_shift_up: String = "Shift Up"
+## The name of the input map used for shiftinf down a gear when
+## manual transmission is enabled.
+## [br]The input map must be present in your project, and can be set at [code]Project > Project Settings > Input Map[/code].
+## [br]Leave blank to disable.
+@export var string_shift_down: String = "Shift Down"
+
 func _physics_process(_delta):
-	pass # Handled by vehicle.gd
+	
+	if string_brake_input != "":
+		vehicle_node.brake_input = Input.get_action_strength(string_brake_input)
+
+	if string_steer_left != "" and string_steer_right != "":
+		vehicle_node.steering_input = Input.get_action_strength(string_steer_left) - Input.get_action_strength(string_steer_right)
+
+	if string_throttle_input != "":
+		vehicle_node.throttle_input = pow(Input.get_action_strength(string_throttle_input), 2.0)
+
+	if string_handbrake_input != "":
+		vehicle_node.handbrake_input = Input.get_action_strength(string_handbrake_input)
+	
+	if string_clutch_input != "":
+		vehicle_node.clutch_input = clampf(Input.get_action_strength(string_clutch_input) + Input.get_action_strength(string_handbrake_input), 0.0, 1.0)
+	
+	if string_toggle_transmission != "":
+		if Input.is_action_just_pressed(string_toggle_transmission):
+			vehicle_node.automatic_transmission = not vehicle_node.automatic_transmission
+	
+	if string_shift_up != "":
+		if Input.is_action_just_pressed(string_shift_up):
+			vehicle_node.manual_shift(1)
+	
+	if string_shift_down != "":
+		if Input.is_action_just_pressed(string_shift_down):
+			vehicle_node.manual_shift(-1)
+	
+	# Reverse gear logic
+
+	if vehicle_node.current_gear == -1:
+		vehicle_node.brake_input = Input.get_action_strength(string_throttle_input)
+		vehicle_node.throttle_input = Input.get_action_strength(string_brake_input)

--- a/addons/gevp/scripts/vehicle_controllergd.gd
+++ b/addons/gevp/scripts/vehicle_controllergd.gd
@@ -1,6 +1,8 @@
 extends Node3D
+## Controls any [Vehicle] node using custom-defined input maps.
+class_name VehicleController
 
-## The Vehicle that this vehicle controller will send
+## The [Vehicle] that this vehicle controller will send
 ## input values to. Required for the vehicle controller to work properly.
 @export var vehicle_node : Vehicle
 


### PR DESCRIPTION
Input logic is now handled in `vehicle.gd` instead of `vehicle_controllergd.gd`
also, making the input maps Match up with ones in the project, or deleting them completely, no longer requires editing code, only changing exported variables
it Does make it more difficult to do other things with those inputs by editing the code but it also reduces to need to do that for most projects

Partially fixes #10; this doesn't dynamically add input maps at runtime for reasons I already showed but it does make it easier to change or remove them
